### PR TITLE
Improved version

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
-# GPT-Siri
-A Siri ChatGPT shortcut that takes full of advantage of the new ChatGPT shortcut actions in the 1.2023.152 update.
+# ChatGPT Pro Plus
+
+This is a Siri ChatGPT shortcut that uses the new ChatGPT shortcut actions in the 1.2023.152 update. It allows you to have a natural and continuous conversation with Siri without stopping for commands. You can also save your chat history locally for privacy reasons (disable server saving in the app settings). Additionally, you can handle large files, URLs, and texts using ChatGPT Uploader, a tool created by Reddit user u/VitorCallis and Instagram user @VitorCallis. My shortcut is inspired by https://github.com/Yue-Yang/ChatGPT-Siri.
+
+To use this shortcut, you need to download two overall shortcuts from the following links:
+
+My shortcut: https://www.icloud.com/shortcuts/d8c74f746c1b435a9fd7d80d5dfc56f0 ChatGPT Uploader (modified to match my shortcut): https://www.icloud.com/shortcuts/591a6628bc694862af92307fb5bfdb04
 
 # Requirements
 The shortcut needs **iOS 16.1** to be able to use. This is due to the fact that **the ChatGPT app requires iOS 16.1**, not because I want a minimal amount of people to use the shortcut.

--- a/README.md
+++ b/README.md
@@ -1,13 +1,1 @@
-# ChatGPT Pro Plus
 
-This is a Siri ChatGPT shortcut that uses the new ChatGPT shortcut actions in the 1.2023.152 update. It allows you to have a natural and continuous conversation with Siri without stopping for commands. You can also save your chat history locally for privacy reasons (disable server saving in the app settings). Additionally, you can handle large files, URLs, and texts using ChatGPT Uploader, a tool created by Reddit user u/VitorCallis and Instagram user @VitorCallis. My shortcut is inspired by https://github.com/Yue-Yang/ChatGPT-Siri.
-
-To use this shortcut, you need to download two overall shortcuts from the following links:
-
-My shortcut: https://www.icloud.com/shortcuts/d8c74f746c1b435a9fd7d80d5dfc56f0 ChatGPT Uploader (modified to match my shortcut): https://www.icloud.com/shortcuts/591a6628bc694862af92307fb5bfdb04
-
-# Requirements
-The shortcut needs **iOS 16.1** to be able to use. This is due to the fact that **the ChatGPT app requires iOS 16.1**, not because I want a minimal amount of people to use the shortcut.
-
-# ⚠️‼️ KNOWN ISSUES ‼️⚠️
-On iOS 17, copy to clipboard doesn't work. **This is a Shortcut bug. Report this to the Feedback app.**


### PR DESCRIPTION
ChatGPT Pro Plus

This is a Siri ChatGPT shortcut that uses the new ChatGPT shortcut actions in the 1.2023.152 update. It allows you to have a natural and continuous conversation with Siri without stopping for commands. You can also save your chat history locally for privacy reasons (disable server saving in the app settings). Additionally, you can handle large files, URLs, and texts using ChatGPT Uploader, a tool created by Reddit user u/VitorCallis and Instagram user @VitorCallis. My shortcut is inspired by https://github.com/Yue-Yang/ChatGPT-Siri.

To use this shortcut, you need to download two overall shortcuts from the following links:

My shortcut: https://www.icloud.com/shortcuts/d8c74f746c1b435a9fd7d80d5dfc56f0 ChatGPT Uploader (modified to match my shortcut): https://www.icloud.com/shortcuts/591a6628bc694862af92307fb5bfdb04